### PR TITLE
Fixes parsing of attribute names containing digits

### DIFF
--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -69,7 +69,7 @@ module JSONTranslate
       # Returns the attribute name Symbol, locale Symbol, and a Boolean
       # indicating whether or not the caller is attempting to assign a value.
       def parse_translated_attribute_accessor(method_name)
-        return unless /\A(?<attribute>[a-z_]+)_(?<locale>[a-z]{2})(?<assignment>=?)\z/ =~ method_name
+        return unless /\A(?<attribute>[a-z0-9_]+)_(?<locale>[a-z]{2})(?<assignment>=?)\z/ =~ method_name
 
         translated_attr_name = attribute.to_sym
         return unless translated_attribute_names.include?(translated_attr_name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ DatabaseCleaner.strategy = :transaction
 I18n.available_locales = [:en, :fr]
 
 class Post < ActiveRecord::Base
-  translates :title
+  translates :title, :body_1
 end
 
 class PostDetailed < Post
@@ -45,6 +45,7 @@ class JSONTranslate::Test < Minitest::Test
       connection = establish_connection(db_config)
       connection.create_table(:posts, :force => true) do |t|
         t.column :title_translations, 'jsonb'
+        t.column :body_1_translations, 'jsonb'
         t.column :comment_translations, 'jsonb'
       end
     end

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -4,15 +4,20 @@ require 'test_helper'
 class TranslatesTest < JSONTranslate::Test
   def test_assigns_in_current_locale
     I18n.with_locale(:en) do
-      p = Post.new(:title => "English Title")
+      p = Post.new(:title => "English Title", :body_1 => "English Body")
       assert_equal("English Title", p.title_translations['en'])
+      assert_equal("English Body", p.body_1_translations['en'])
     end
   end
 
   def test_retrieves_in_current_locale
-    p = Post.new(:title_translations => { "en" => "English Title", "fr" => "Titre français" })
+    p = Post.new(
+      :title_translations => { "en" => "English Title", "fr" => "Titre français" },
+      :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" }
+    )
     I18n.with_locale(:fr) do
       assert_equal("Titre français", p.title)
+      assert_equal("Corps anglais", p.body_1)
     end
   end
 
@@ -20,33 +25,39 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => {"en" => "English Title"})
+    p = Post.new(:title_translations => {"en" => "English Title"}, :body_1_translations => { "en" => "English Body" })
     I18n.with_locale(:fr) do
       assert_equal("English Title", p.title)
+      assert_equal("English Body", p.body_1)
     end
   end
 
   def test_assigns_in_specified_locale
     I18n.with_locale(:en) do
-      p = Post.new(:title_translations => { "en" => "English Title" })
+      p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
       p.title_fr = "Titre français"
+      p.body_1_fr = "Corps anglais"
       assert_equal("Titre français", p.title_translations["fr"])
+      assert_equal("Corps anglais", p.body_1_translations["fr"])
     end
   end
 
   def test_persists_changes_in_specified_locale
     I18n.with_locale(:en) do
-      p = Post.create!(:title_translations => { "en" => "Original Text" })
+      p = Post.create!(:title_translations => { "en" => "Original Text" }, :body_1_translations => { "en" => "Original Body" })
       p.title_en = "Updated Text"
+      p.body_1_en = "Updated Body"
       p.save!
       assert_equal("Updated Text", Post.last.title_en)
+      assert_equal("Updated Body", Post.last.body_1_en)
     end
   end
 
   def test_retrieves_in_specified_locale
     I18n.with_locale(:en) do
-      p = Post.new(:title_translations => { "en" => "English Title", "fr" => "Titre français" })
+      p = Post.new(:title_translations => { "en" => "English Title", "fr" => "Titre français" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
       assert_equal("Titre français", p.title_fr)
+      assert_equal("Corps anglais", p.body_1_fr)
     end
   end
 
@@ -54,9 +65,10 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     I18n.with_locale(:fr) do
       assert_equal("English Title", p.title_fr)
+      assert_equal("English Body", p.body_1_fr)
     end
   end
 
@@ -64,9 +76,10 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title", "fr" => "" })
+    p = Post.new(:title_translations => { "en" => "English Title", "fr" => "" }, :body_1_translations => { "en" => "English Body", "fr" => "" })
     I18n.with_locale(:fr) do
       assert_equal("English Title", p.title_fr)
+      assert_equal("English Body", p.body_1_fr)
     end
   end
 
@@ -74,10 +87,11 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback
     I18n.with_locale(:fr) do
-      assert_equal(nil, p.title_fr)
+      assert_nil(p.title_fr)
+      assert_nil(p.body_1_fr)
     end
   end
 
@@ -85,22 +99,27 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.enable_fallback
 
     assert_equal("English Title", p.title_fr)
-    p.disable_fallback { assert_nil p.title_fr }
+    assert_equal("English Body", p.body_1_fr)
+    p.disable_fallback do
+      assert_nil p.title_fr
+      assert_nil p.body_1_fr
+    end
   end
 
   def test_retrieves_in_specified_locale_with_fallback_reenabled
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback
     p.enable_fallback
     I18n.with_locale(:fr) do
       assert_equal("English Title", p.title_fr)
+      assert_equal("English Body", p.body_1_fr)
     end
   end
 
@@ -108,11 +127,15 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => { "en" => "English Title" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback
 
     assert_nil(p.title_fr)
-    p.enable_fallback { assert_equal("English Title", p.title_fr) }
+    assert_nil(p.body_1_fr)
+    p.enable_fallback do
+      assert_equal("English Title", p.title_fr)
+      assert_equal("English Body", p.body_1_fr)
+    end
   end
 
   def test_method_missing_delegates
@@ -124,21 +147,24 @@ class TranslatesTest < JSONTranslate::Test
   end
 
   def test_persists_translations_assigned_as_hash
-    p = Post.create!(:title_translations => { "en" => "English Title", "fr" => "Titre français" })
+    p = Post.create!(:title_translations => { "en" => "English Title", "fr" => "Titre français" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
     p.reload
     assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
+    assert_equal({"en" => "English Body", "fr" => "Corps anglais"}, p.body_1_translations)
   end
 
   def test_persists_translations_assigned_to_localized_accessors
-    p = Post.create!(:title_en => "English Title", :title_fr => "Titre français")
+    p = Post.create!(:title_en => "English Title", :title_fr => "Titre français", :body_1_en => "English Body", :body_1_fr => "Corps anglais")
     p.reload
     assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
+    assert_equal({"en" => "English Body", "fr" => "Corps anglais"}, p.body_1_translations)
   end
 
   def test_with_translation_relation
-    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland", "fr" => "Alice au pays des merveilles" })
+    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland", "fr" => "Alice au pays des merveilles" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
     I18n.with_locale(:en) do
       assert_equal p.title_en, Post.with_title_translation("Alice in Wonderland").first.try(:title)
+      assert_equal p.body_1_en, Post.with_body_1_translation("English Body").first.try(:body_1)
     end
   end
 
@@ -153,6 +179,10 @@ class TranslatesTest < JSONTranslate::Test
         "en" => "Alice in Wonderland",
         "fr" => "Alice au pays des merveilles"
       },
+      :body_1_translations => {
+        "en" => "English Body",
+        "fr" => "Corps anglais"
+      },
       :comment_translations => {
         "en" => "Awesome book",
         "fr" => "Un livre unique"
@@ -161,11 +191,13 @@ class TranslatesTest < JSONTranslate::Test
 
     I18n.with_locale(:en) { assert_equal "Awesome book", p.comment }
     I18n.with_locale(:en) { assert_equal "Alice in Wonderland", p.title }
+    I18n.with_locale(:en) { assert_equal "English Body", p.body_1 }
     I18n.with_locale(:fr) { assert_equal "Un livre unique", p.comment }
     I18n.with_locale(:fr) { assert_equal "Alice au pays des merveilles", p.title }
+    I18n.with_locale(:fr) { assert_equal "Corps anglais", p.body_1 }
   end
 
   def test_permitted_translated_attributes
-    assert_equal [:title_en, :title_fr, :comment_en, :comment_fr], PostDetailed.permitted_translated_attributes
+    assert_equal [:title_en, :title_fr, :body_1_en, :body_1_fr, :comment_en, :comment_fr], PostDetailed.permitted_translated_attributes
   end
 end


### PR DESCRIPTION
The regex in parse_translated_attribute_accessor was excluding attribute names that had digits in their name.