### PR TITLE
Add interpolation

### DIFF
--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -18,8 +18,8 @@ module JSONTranslate
       ].flatten.compact
 
       attrs.each do |attr_name|
-        define_method attr_name do
-          read_json_translation(attr_name)
+        define_method attr_name do |**params|
+          read_json_translation(attr_name, params)
         end
 
         define_method "#{attr_name}=" do |value|

--- a/lib/json_translate/translates/active_record_with_json_translates.rb
+++ b/lib/json_translate/translates/active_record_with_json_translates.rb
@@ -6,15 +6,15 @@ module JSONTranslate
         super(symbol, include_all)
       end
 
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, **params)
         translated_attr_name, locale, assigning = parse_translated_attribute_accessor(method_name)
 
-        return super(method_name, *args) unless translated_attr_name
+        return super(method_name, *args, **params) unless translated_attr_name
 
         if assigning
           write_json_translation(translated_attr_name, args.first, locale)
         else
-          read_json_translation(translated_attr_name, locale)
+          read_json_translation(translated_attr_name, locale, **params)
         end
       end
     end

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -26,8 +26,13 @@ module JSONTranslate
         end
 
         translation = translations[available.to_s]
-
-        I18n.interpolate(translation, params) if translation
+        # Rescue from MissingInterpolationArgument
+        # so the default behaviour doesn't change
+        begin
+          I18n.interpolate(translation, params) if translation
+        rescue I18n::MissingInterpolationArgument
+          translation
+        end
       end
 
       def write_json_translation(attr_name, value, locale = I18n.locale)

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -18,14 +18,16 @@ module JSONTranslate
         I18n.fallbacks[locale]
       end
 
-      def read_json_translation(attr_name, locale = I18n.locale)
+      def read_json_translation(attr_name, locale = I18n.locale, **params)
         translations = public_send("#{attr_name}#{SUFFIX}") || {}
 
         available = Array(json_translate_fallback_locales(locale)).detect do |available_locale|
           translations[available_locale.to_s].present?
         end
 
-        translations[available.to_s]
+        translation = translations[available.to_s]
+
+        I18n.interpolate(translation, params) if translation
       end
 
       def write_json_translation(attr_name, value, locale = I18n.locale)

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -142,6 +142,14 @@ class TranslatesTest < JSONTranslate::Test
     end
   end
 
+  def test_with_translation_attributes
+    p = Post.create!(:title_translations => { "en" => "Alice in %{where}" })
+    I18n.with_locale(:en) do
+      assert_equal p.title(where: "Wonderland"), "Alice in Wonderland"
+    end
+    assert_equal p.title_en(where: "Wonderland"), "Alice in Wonderland"
+  end
+
   def test_class_method_translates?
     assert_equal true, Post.translates?
     assert_equal true, PostDetailed.translates?

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -142,12 +142,17 @@ class TranslatesTest < JSONTranslate::Test
     end
   end
 
-  def test_with_translation_attributes
+  def test_with_interpolation_arguments
     p = Post.create!(:title_translations => { "en" => "Alice in %{where}" })
     I18n.with_locale(:en) do
       assert_equal p.title(where: "Wonderland"), "Alice in Wonderland"
     end
     assert_equal p.title_en(where: "Wonderland"), "Alice in Wonderland"
+  end
+
+  def test_for_missing_interpolation_arguments
+    p = Post.create!(:title_translations => { "en" => "Alice in %{where}" })
+    assert_equal p.title_en, "Alice in %{where}"
   end
 
   def test_class_method_translates?


### PR DESCRIPTION
Adds option to use argument interpolation, like in `I18n`. 

Suppresses the `I18n:: MissingInterpolationArgument` error to not create any breaking changes if someone has their own interpolation set up.