### PR TITLE
Add MySQL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,26 @@ rvm:
 gemfile:
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-5.0.x
-matrix:
+env:
+  - DB=mysql
+  - DB=postgres
 addons:
   postgresql: "9.4"
+matrix:
+  exclude:
+    gemfile: test/gemfiles/Gemfile.rails-4.2.x
+    env: DB=mysql
+before_install:
+  - gem install bundler
+  - if [[ $DB == mysql ]] ;
+    then
+      echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | sudo debconf-set-selections ;
+      wget http://dev.mysql.com/get/mysql-apt-config_0.7.3-1_all.deb ;
+      sudo dpkg --install mysql-apt-config_0.7.3-1_all.deb ;
+      sudo apt-get update -q ;
+      sudo apt-get install -q -y --allow-unauthenticated -o Dpkg::Options::=--force-confnew mysql-server ;
+      sudo mysql_upgrade ;
+      mysql -e 'create database json_translate_test;' ;
+    else
+      psql -c 'create database json_translate_test;' -U postgres ;
+    fi

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gemspec
 
 gem 'pg', :platform => :ruby
 gem 'activerecord-jdbcpostgresql-adapter', :platform => :jruby
+gem 'mysql2', :platform => :ruby
+gem 'activerecord-jdbcmysql-adapter', :platform => :jruby

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
+[![Gem Version](https://badge.fury.io/rb/json_translate.svg)](https://badge.fury.io/rb/json_translate)
+[![Build Status](https://api.travis-ci.org/cfabianski/json_translate.png)](https://travis-ci.org/cfabianski/json_translate)
+[![License](http://img.shields.io/badge/license-mit-brightgreen.svg)](COPYRIGHT)
+[![Code Climate](https://codeclimate.com/github/cfabianski/json_translate.png)](https://codeclimate.com/github/cfabianski/json_translate)
+
 # JSON Translate
 
 Rails I18n library for ActiveRecord model/data translation using PostgreSQL's
 JSONB datatype. It provides an interface inspired by
 [Globalize3](https://github.com/svenfuchs/globalize3) but removes the need to
 maintain separate translation tables.
-
-[![Build Status](https://api.travis-ci.org/cfabianski/json_translate.png)](https://travis-ci.org/cfabianski/json_translate)
-[![License](http://img.shields.io/badge/license-mit-brightgreen.svg)](COPYRIGHT)
-[![Code Climate](https://codeclimate.com/github/cfabianski/json_translate.png)](https://codeclimate.com/github/cfabianski/json_translate)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # JSON Translate
 
 Rails I18n library for ActiveRecord model/data translation using PostgreSQL's
-JSONB datatype. It provides an interface inspired by
+JSONB datatype or MySQL's JSON datatype. It provides an interface inspired by
 [Globalize3](https://github.com/svenfuchs/globalize3) but removes the need to
 maintain separate translation tables.
 
@@ -14,6 +14,7 @@ maintain separate translation tables.
 
 * ActiveRecord >= 4.2.0
 * I18n
+* MySQL support requires ActiveRecord >= 5 and MySQL >= 5.7.8.
 
 ## Installation
 
@@ -25,8 +26,15 @@ When using bundler, put it in your Gemfile:
 source 'https://rubygems.org'
 
 gem 'activerecord'
+
+# PostgreSQL
 gem 'pg', :platform => :ruby
 gem 'activerecord-jdbcpostgresql-adapter', :platform => :jruby
+
+# or MySQL
+gem 'mysql2', :platform => :ruby
+gem 'activerecord-jdbcmysql-adapter', :platform => :jruby
+
 gem 'json_translate'
 ```
 
@@ -58,21 +66,21 @@ post.title # => This database rocks!
 post.title_he # => אתר זה טוב
 ```
 
-To find records using translations without constructing JSONB queries by hand:
+To find records using translations without constructing JSON queries by hand:
 
 ```ruby
 Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relation ...>
 Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
 ```
 
-In order to make this work, you'll need to define an JSONB column for each of
+In order to make this work, you'll need to define an JSON or JSONB column for each of
 your translated attributes, using the suffix "_translations":
 
 ```ruby
 class CreatePosts < ActiveRecord::Migration
   def up
     create_table :posts do |t|
-      t.column :title_translations, 'jsonb'
+      t.column :title_translations, 'jsonb' # or 'json' for MySQL
       t.column :body_translations,  'jsonb'
       t.timestamps
     end

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,6 +1,13 @@
-test:
+postgres:
   adapter:  postgresql
   host:     localhost
   database: json_translate_test
   username: postgres
+  schema_search_path: public
   min_messages: warning
+
+mysql:
+  adapter:  mysql2
+  host:     localhost
+  database: json_translate_test
+  username: root

--- a/test/gemfiles/Gemfile.rails-4.2.x
+++ b/test/gemfiles/Gemfile.rails-4.2.x
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 gemspec :path => './../..'
 
 gem 'pg'
+gem 'mysql2'
 gem 'activerecord', '~> 4.2.0'

--- a/test/gemfiles/Gemfile.rails-5.0.x
+++ b/test/gemfiles/Gemfile.rails-5.0.x
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 gemspec :path => './../..'
 
 gem 'pg'
+gem 'mysql2'
 gem 'activerecord', '~> 5.0.0'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,10 +23,14 @@ class JSONTranslate::Test < Minitest::Test
 
     private
 
+    def adapter
+      @adapter ||= ENV['DB'] || 'postgres'
+    end
+
     def db_config
       @db_config ||= begin
         filepath = File.join('test', 'database.yml')
-        YAML.load_file(filepath)['test']
+        YAML.load_file(filepath)[adapter]
       end
     end
 
@@ -36,16 +40,17 @@ class JSONTranslate::Test < Minitest::Test
     end
 
     def create_database
-      system_config = db_config.merge('database' => 'postgres', 'schema_search_path' => 'public')
+      system_config = db_config
       connection = establish_connection(system_config)
       connection.create_database(db_config['database']) rescue nil
     end
 
     def create_table
+      column_type = adapter == 'mysql' ? 'json' : 'jsonb'
       connection = establish_connection(db_config)
       connection.create_table(:posts, :force => true) do |t|
-        t.column :title_translations, 'jsonb'
-        t.column :comment_translations, 'jsonb'
+        t.column :title_translations, column_type
+        t.column :comment_translations, column_type
       end
     end
   end


### PR DESCRIPTION
Thanks for a great gem.  MySQL 5.7.8 now has a JSON data type and Rails 5 added support for it.  The gem almost completely worked out of the box -- it just required an adapter check in `with_#{attr_name}_translation`.

Unfortunately Travis doesn't have native MySQL 5.7 support so we have to install it in the build script.

I'm planning on using this in one of our projects -- hopefully someone else finds it useful, too.