### PR TITLE
Make sure passed in block yields its value

### DIFF
--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -3,10 +3,12 @@ module JSONTranslate
     module InstanceMethods
       def disable_fallback
         toggle_fallback(false)
+        yield if block_given?
       end
 
       def enable_fallback
         toggle_fallback(true)
+        yield if block_given?
       end
 
       protected

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -119,14 +119,16 @@ class TranslatesTest < JSONTranslate::Test
       assert_nil(p.body_1_fr)
       assert_equal("English Title", p.title_en)
       assert_equal("English Body", p.body_1_en)
-      p.disable_fallback do
+      yielded = p.disable_fallback do
         assert_nil(p.title)
         assert_nil(p.body_1)
         assert_nil(p.title_fr)
         assert_nil(p.body_1_fr)
         assert_equal("English Title", p.title_en)
         assert_equal("English Body", p.body_1_en)
+        :block_return_value
       end
+      assert_equal(:block_return_value, yielded)
     end
   end
 
@@ -161,14 +163,16 @@ class TranslatesTest < JSONTranslate::Test
       assert_nil(p.body_1_fr)
       assert_equal("English Title", p.title_en)
       assert_equal("English Body", p.body_1_en)
-      p.enable_fallback do
+      yielded = p.enable_fallback do
         assert_equal("English Title", p.title)
         assert_equal("English Body", p.body_1)
         assert_nil(p.title_fr)
         assert_nil(p.body_1_fr)
         assert_equal("English Title", p.title_en)
         assert_equal("English Body", p.body_1_en)
+        :block_return_value
       end
+      assert_equal(:block_return_value, yielded)
     end
   end
 


### PR DESCRIPTION
I have a Rails view where I can edit every available translation of a record in a form:

```slim
= form_for @record do |f|
  - I18n.available_locales do |locale|
    - f.object.disable_fallback do
      = f.input "title_#{locale}"
```

However, it doesn't write out anything to the DOM, because `disable_fallback` silently swallows the inner parts of the block. I provided a regression test case to demonstrate how it fails.

With this PR the form shows up properly (again). I'm not sure why it stopped working, because I know it worked before in my application. Maybe something changed in the current Ruby version, I haven't looked that up. At any rate, now the original block is passed on to the underlying `toggle_fallback` method.

Thank you for your time!