### PR TITLE
Fallbacks for empty translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 pkg/*
 test/coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -103,9 +103,32 @@ only `config/environments/production.rb` if you only want them in production)
 ```ruby
 config.i18n.fallbacks = true
 ```
-
 Sven Fuchs wrote a [detailed explanation of the fallback
 mechanism](https://github.com/svenfuchs/i18n/wiki/Fallbacks).
+
+## I18n fallbacks for empty translations
+It is possible to enable fallbacks for missing translations. 
+By default, JSON_translate will only use fallbacks when your translation 
+JSON column does not exist or the translation value for the item you've request is nil.
+However it is possible to use fallbacks for empty translations by adding 
+`:fallbacks_for_empty_translations => true` to the `translates` method
+
+```ruby
+class Post < ActiveRecord::Base
+  translates :title, :name, :fallbacks_for_empty_translations => true
+end
+
+puts post.inspect
+# => <PostDetailed id: 1, title_translations: {"en"=>"This database rocks", "nl"=>""}, name: {"en"=>"PostgreSQL", "nl"=>""}>
+
+I18n.locale = :en
+post.title # => 'This database rocks!'
+post.name  # => 'PostgreSQL'
+
+I18n.locale = :nl
+post.title # => 'This database rocks!'
+post.name  # => 'PostgreSQL'
+```
 
 ## Temporarily disable fallbacks
 

--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -3,7 +3,7 @@ module JSONTranslate
     SUFFIX = "_translations".freeze
     MYSQL_ADAPTERS = %w[MySQL Mysql2 Mysql2Spatial]
 
-    def translates(*attrs)
+    def translates(*attrs, **fallback)
       include InstanceMethods
 
       class_attribute :translated_attribute_names, :permitted_translated_attributes
@@ -11,10 +11,10 @@ module JSONTranslate
       self.translated_attribute_names = attrs
       self.permitted_translated_attributes = [
         *self.ancestors
-          .select {|klass| klass.respond_to?(:permitted_translated_attributes) }
-          .map(&:permitted_translated_attributes),
+           .select { |klass| klass.respond_to?(:permitted_translated_attributes) }
+           .map(&:permitted_translated_attributes),
         *attrs.product(I18n.available_locales)
-          .map { |attribute, locale| :"#{attribute}_#{locale}" }
+           .map { |attribute, locale| :"#{attribute}_#{locale}" }
       ].flatten.compact
 
       attrs.each do |attr_name|

--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -3,7 +3,7 @@ module JSONTranslate
     SUFFIX = "_translations".freeze
     MYSQL_ADAPTERS = %w[MySQL Mysql2 Mysql2Spatial]
 
-    def translates(*attrs)
+    def translates(*attrs, **fallback)
       include InstanceMethods
 
       class_attribute :translated_attribute_names, :permitted_translated_attributes
@@ -16,10 +16,9 @@ module JSONTranslate
         *attrs.product(I18n.available_locales)
            .map { |attribute, locale| :"#{attribute}_#{locale}" }
       ].flatten.compact
-
       attrs.each do |attr_name|
         define_method attr_name do |**params|
-          read_json_translation(attr_name, params)
+          read_json_translation(attr_name, params.merge(fallback))
         end
 
         define_method "#{attr_name}=" do |value|

--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -3,7 +3,7 @@ module JSONTranslate
     SUFFIX = "_translations".freeze
     MYSQL_ADAPTERS = %w[MySQL Mysql2 Mysql2Spatial]
 
-    def translates(*attrs, **fallback)
+    def translates(*attrs)
       include InstanceMethods
 
       class_attribute :translated_attribute_names, :permitted_translated_attributes

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -23,13 +23,18 @@ module JSONTranslate
         end
       end
 
-      def read_json_translation(attr_name, locale = I18n.locale, fallback = true, **params)
+      def read_json_translation(attr_name, locale = I18n.locale, fallback = true, fallbacks_for_empty_translations = false, **params)
+
         translations = public_send("#{attr_name}#{SUFFIX}") || {}
 
         selected_locale = locale
         if fallback
           selected_locale = json_translate_fallback_locales(locale).detect do |available_locale|
-            translations[available_locale.to_s].present?
+            selected = translations[available_locale.to_s].present?
+            if fallbacks_for_empty_translations
+              selected &&= translations[available_locale.to_s] != ''
+            end
+            selected
           end
         end
 

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -23,7 +23,7 @@ module JSONTranslate
         end
       end
 
-      def read_json_translation(attr_name, locale = I18n.locale, fallback = true, fallbacks_for_empty_translations = false, **params)
+      def read_json_translation(attr_name, locale = I18n.locale, fallback = true, fallbacks_for_empty_translations: false, **params)
 
         translations = public_send("#{attr_name}#{SUFFIX}") || {}
 
@@ -32,7 +32,7 @@ module JSONTranslate
           selected_locale = json_translate_fallback_locales(locale).detect do |available_locale|
             selected = translations[available_locale.to_s].present?
             if fallbacks_for_empty_translations
-              selected &&= translations[available_locale.to_s].empty?
+              selected &&= !translations[available_locale.to_s].empty?
             end
             selected
           end

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -32,7 +32,7 @@ module JSONTranslate
           selected_locale = json_translate_fallback_locales(locale).detect do |available_locale|
             selected = translations[available_locale.to_s].present?
             if fallbacks_for_empty_translations
-              selected &&= translations[available_locale.to_s] != ''
+              selected &&= translations[available_locale.to_s].empty?
             end
             selected
           end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class Post < ActiveRecord::Base
 end
 
 class PostDetailed < Post
-  translates :comment
+  translates :comment, fallbacks_for_empty_translations: true
 end
 
 class JSONTranslate::Test < Minitest::Test

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -256,22 +256,29 @@ class TranslatesTest < JSONTranslate::Test
   def test_empty_string_fallback
     p = PostDetailed.create!(
       :title_translations => {
-        en: 'Alice in Wonderland',
-        fr: ''
+        en: "Alice in Wonderland",
+        fr: ""
       },
       :body_1_translations => {
-        en: '',
-        fr: 'Corps anglais'
+        en: "",
+        fr: "Corps anglais"
       },
       :comment_translations => {
-        en: 'Awesome book',
-        fr: ''
+        en: "Awesome book",
+        fr: ""
       }
     )
+    p.enable_fallback
 
     I18n.with_locale(:en) { assert_equal 'Alice in Wonderland', p.title }
     I18n.with_locale(:fr) { assert_equal 'Alice in Wonderland', p.title }
     I18n.with_locale(:en) { assert_equal 'Awesome book', p.comment }
     I18n.with_locale(:fr) { assert_equal 'Awesome book', p.comment }
+
+    p.disable_fallback
+    I18n.with_locale(:en) { assert_equal 'Alice in Wonderland', p.title }
+    I18n.with_locale(:fr) { assert_nil p.title }
+    I18n.with_locale(:en) { assert_equal 'Awesome book', p.comment }
+    I18n.with_locale(:fr) { assert_nil p.comment }
   end
 end

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -25,7 +25,7 @@ class TranslatesTest < JSONTranslate::Test
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
 
-    p = Post.new(:title_translations => {"en" => "English Title"}, :body_1_translations => { "en" => "English Body" })
+    p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     I18n.with_locale(:fr) do
       assert_equal("English Title", p.title)
       assert_equal("English Body", p.body_1)
@@ -187,15 +187,15 @@ class TranslatesTest < JSONTranslate::Test
   def test_persists_translations_assigned_as_hash
     p = Post.create!(:title_translations => { "en" => "English Title", "fr" => "Titre français" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
     p.reload
-    assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
-    assert_equal({"en" => "English Body", "fr" => "Corps anglais"}, p.body_1_translations)
+    assert_equal({ "en" => "English Title", "fr" => "Titre français" }, p.title_translations)
+    assert_equal({ "en" => "English Body", "fr" => "Corps anglais" }, p.body_1_translations)
   end
 
   def test_persists_translations_assigned_to_localized_accessors
     p = Post.create!(:title_en => "English Title", :title_fr => "Titre français", :body_1_en => "English Body", :body_1_fr => "Corps anglais")
     p.reload
-    assert_equal({"en" => "English Title", "fr" => "Titre français"}, p.title_translations)
-    assert_equal({"en" => "English Body", "fr" => "Corps anglais"}, p.body_1_translations)
+    assert_equal({ "en" => "English Title", "fr" => "Titre français" }, p.title_translations)
+    assert_equal({ "en" => "English Body", "fr" => "Corps anglais" }, p.body_1_translations)
   end
 
   def test_with_translation_relation
@@ -250,5 +250,28 @@ class TranslatesTest < JSONTranslate::Test
 
   def test_permitted_translated_attributes
     assert_equal [:title_en, :title_fr, :body_1_en, :body_1_fr, :comment_en, :comment_fr], PostDetailed.permitted_translated_attributes
+  end
+
+
+  def test_empty_string_fallback
+    p = PostDetailed.create!(
+      :title_translations => {
+        en: 'Alice in Wonderland',
+        fr: ''
+      },
+      :body_1_translations => {
+        en: '',
+        fr: 'Corps anglais'
+      },
+      :comment_translations => {
+        en: 'Awesome book',
+        fr: ''
+      }
+    )
+
+    I18n.with_locale(:en) { assert_equal 'Alice in Wonderland', p.title }
+    I18n.with_locale(:fr) { assert_equal 'Alice in Wonderland', p.title }
+    I18n.with_locale(:en) { assert_equal 'Awesome book', p.comment }
+    I18n.with_locale(:fr) { assert_equal 'Awesome book', p.comment }
   end
 end


### PR DESCRIPTION
Hello,

Since I have been using `globalize` and wanted to replace it with `json_translate`, I came across a feature from globalize that was useful for me. The fallback for empty translations. https://github.com/globalize/globalize#i18n-fallbacks-for-empty-translations

Here's the PR to add that feature if you feel like it!

Cheers!