### PR TITLE
Add order by for translated fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,15 @@ Post.with_title_translation("This database rocks!") # => #<ActiveRecord::Relatio
 Post.with_title_translation("אתר זה טוב", :he) # => #<ActiveRecord::Relation ...>
 ```
 
+To order records using translations without constructing JSON queries by hand:
+
+```ruby
+Post.order_by_title_translation # => #<ActiveRecord::Relation ...>
+Post.order_by_title_translation(:asc) # => #<ActiveRecord::Relation ...>
+Post.order_by_title_translation(:desc) # => #<ActiveRecord::Relation ...>
+Post.order_by_title_translation(:desc, :he) # => #<ActiveRecord::Relation ...>
+```
+
 In order to make this work, you'll need to define an JSON or JSONB column for each of
 your translated attributes, using the suffix "_translations":
 

--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -48,6 +48,16 @@ module JSONTranslate
             where("#{quoted_translation_store} @> :translation::jsonb", translation: translation_hash.to_json)
           end
         end
+
+        define_singleton_method "order_by_#{attr_name}_translation" do |direction = :asc, locale = I18n.locale|
+          quoted_translation_store = connection.quote_column_name("#{attr_name}#{SUFFIX}")
+
+          if MYSQL_ADAPTERS.include?(connection.adapter_name)
+            order(Arel.sql("JSON_EXTRACT(#{quoted_translation_store}, '$.\"#{locale}\"') #{direction}"))
+          else
+            order(Arel.sql("#{quoted_translation_store} ->> '#{locale}' #{direction}"))
+          end
+        end
       end
     end
 

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -206,6 +206,17 @@ class TranslatesTest < JSONTranslate::Test
     end
   end
 
+  def test_order_by_translation
+    p = Post.create!(:title_translations => { "en" => "Alice in Wonderland", "fr" => "Alice au pays des merveilles" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
+    p2 = Post.create!(:title_translations => { "en" => "Zoolander", "fr" => "Zoolandia" }, :body_1_translations => { "en" => "English Body", "fr" => "Corps anglais" })
+    I18n.with_locale(:en) do
+      assert_equal p.title_en, Post.order_by_title_translation.first.try(:title)
+      assert_equal p.title_en, Post.order_by_title_translation(:asc).first.try(:title)
+      assert_equal p2.title_en, Post.order_by_title_translation(:desc).first.try(:title)
+      assert_equal p2.title_en, Post.order_by_title_translation(:desc, :fr).first.try(:title)
+    end
+  end
+
   def test_with_interpolation_arguments
     p = Post.create!(:title_translations => { "en" => "Alice in %{where}" })
     I18n.with_locale(:en) do


### PR DESCRIPTION
I still need to review the quoting for the order by (currently it's hard-coded), there's probably a way to quote them properly using AR methods.  However just checking would you be interested in accepting this functionality?