### PR TITLE
Small refactoring to allow custom handling for AR *_will_change callbacks

### DIFF
--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -49,7 +49,7 @@ module JSONTranslate
         value = value.presence
         translation_store = "#{attr_name}#{SUFFIX}"
         translations = public_send(translation_store) || {}
-        public_send("#{translation_store}_will_change!") unless translations[locale.to_s] == value
+        translation_store_will_change!(translation_store) unless translations[locale.to_s] == value
         if value
           translations[locale.to_s] = value
         else
@@ -57,6 +57,10 @@ module JSONTranslate
         end
         public_send("#{translation_store}=", translations)
         value
+      end
+
+      def translation_store_will_change!(translation_store)
+        public_send("#{translation_store}_will_change!")
       end
 
       def toggle_fallback(enabled)


### PR DESCRIPTION
I'm using `json_translate` in a situation where the store itself is already located inside of a json store. Therefore, the `<store>_will_change!` callbacks do not exists. I was thinking about implementing this handling inside of a PR, but it seemed way too specific for my use-case.
Therefore I just moved the callback to its own method (`translation_store_will_change!`), so that custom handling can easily be achieved by just overriding this method.