### PR TITLE
Feat disable translates

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,55 @@ post.enable_fallback do
   post.title_nl # => This database rocks!
 end
 ```
+
+## Temporarily disable translations / Migrating Data
+
+If you are integrating this gem to an application with existing data, you are probably concerned about how to migrate your data from the untranslated column to your new `attr_translations` column. You can easily disable translations to do what you need when migrating the data over.
+
+Older Schema:
+```ruby
+class CreatePosts < ActiveRecord::Migration
+  def up
+    create_table :posts do |t|
+      t.column :title, :string
+      t.timestamps
+    end
+  end
+  def down
+    drop_table :posts
+  end
+end
+```
+Let's say you originally had something important saved in `title`:
+```ruby
+post.title  = "something important"
+```
+
+You might think it disappeared, but with disable_translations you can still get the old data.
+
+From:
+
+```ruby
+post.title # => nil
+```
+
+To:
+
+```ruby
+post.title # => nil
+post.disable_translations
+post.title # => "something important"
+```
+
+To migrate data, you could do something like:
+
+```ruby
+post.disable_translations
+migrated_title = post.title
+post.enable_translations
+
+I18n.locale = :en
+post.title = migrated_title
+```
+
+

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -58,6 +58,8 @@ module JSONTranslate
       end
 
       def write_json_translation(attr_name, value, locale = I18n.locale)
+        return assign_attributes({attr_name => value}) unless enabled_translations
+
         value = value.presence
         translation_store = "#{attr_name}#{SUFFIX}"
         translations = public_send(translation_store) || {}

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -34,7 +34,7 @@ module JSONTranslate
       end
 
       def read_json_translation(attr_name, locale = I18n.locale, fallback = true, **params)
-        return attributes["#{attr_name}"] unless enabled_translations
+        return attributes["#{attr_name}"] if enabled_translations == false
 
         translations = public_send("#{attr_name}#{SUFFIX}") || {}
 
@@ -58,7 +58,7 @@ module JSONTranslate
       end
 
       def write_json_translation(attr_name, value, locale = I18n.locale)
-        return assign_attributes({attr_name => value}) unless enabled_translations
+        return assign_attributes({attr_name => value}) if enabled_translations == false
 
         value = value.presence
         translation_store = "#{attr_name}#{SUFFIX}"

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -11,9 +11,19 @@ module JSONTranslate
         yield if block_given?
       end
 
+      def disable_translations
+        toggle_translations(false)
+        yield if block_given?
+      end
+
+      def enable_translations
+        toggle_translations(true)
+        yield if block_given?
+      end
+
       protected
 
-      attr_reader :enabled_fallback
+      attr_reader :enabled_fallback, :enabled_translations
 
       def json_translate_fallback_locales(locale)
         if enabled_fallback != false && I18n.respond_to?(:fallbacks)
@@ -24,6 +34,8 @@ module JSONTranslate
       end
 
       def read_json_translation(attr_name, locale = I18n.locale, fallback = true, **params)
+        return attributes["#{attr_name}"] unless enabled_translations
+
         translations = public_send("#{attr_name}#{SUFFIX}") || {}
 
         selected_locale = locale
@@ -70,6 +82,20 @@ module JSONTranslate
           end
         else
           @enabled_fallback = enabled
+        end
+      end
+
+      def toggle_translations(enabled)
+        if block_given?
+          old_value = @enabled_translations
+          begin
+            @enabled_translations = enabled
+            yield
+          ensure
+            @enabled_translations = old_value
+          end
+        else
+          @enabled_translations = enabled
         end
       end
     end


### PR DESCRIPTION
Added similar logic to the enable/disable fallback feature, but to enable/disable translations.

- Support added for toggling the translations on/off via `#disable_translations` & `#enable_translations`
- Support added for using blocks when enabling/disabling translations
- When disabling translations, `#read_json_translation` will return the original attribute. 
- When disabling translations, `#write_json_translation` will write to the original attribute. 
