### PR TITLE
enable empty string values

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,34 @@ post.enable_fallback do
   post.title_nl # => This database rocks!
 end
 ```
+
+## Enable blank value translations
+
+By default, empty String values are not stored, instead the locale is deleted.
+
+```ruby
+class Post < ActiveRecord::Base
+  translates :title
+end
+
+post.title_translations # => { en: 'Hello', fr: 'Bonjour' }
+post.title_en = ""
+post.title_translations # => { fr: 'Bonjour' }
+```
+
+Activating `allow_blank: true` enables to store empty String values.
+```ruby
+class Post < ActiveRecord::Base
+  translates :title, allow_blank: true
+end
+
+post.title_translations # => { en: 'Hello', fr: 'Bonjour' }
+post.title_en = ""
+post.title_translations # => { en: '', fr: 'Bonjour' }
+```
+
+`nil` value delete the locale key/value anyway.
+```ruby
+post.title_en = nil
+post.title_translations # => { fr: 'Bonjour' }
+```

--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -3,7 +3,7 @@ module JSONTranslate
     SUFFIX = "_translations".freeze
     MYSQL_ADAPTERS = %w[MySQL Mysql2 Mysql2Spatial]
 
-    def translates(*attrs)
+    def translates(*attrs, allow_blank: false)
       include InstanceMethods
 
       class_attribute :translated_attribute_names, :permitted_translated_attributes
@@ -23,7 +23,7 @@ module JSONTranslate
         end
 
         define_method "#{attr_name}=" do |value|
-          write_json_translation(attr_name, value)
+          write_json_translation(attr_name, value, allow_blank: allow_blank)
         end
 
         I18n.available_locales.each do |locale|
@@ -34,7 +34,7 @@ module JSONTranslate
           end
 
           define_method "#{attr_name}_#{normalized_locale}=" do |value|
-            write_json_translation(attr_name, value, locale)
+            write_json_translation(attr_name, value, locale, allow_blank: allow_blank)
           end
         end
 

--- a/lib/json_translate/translates/instance_methods.rb
+++ b/lib/json_translate/translates/instance_methods.rb
@@ -45,8 +45,8 @@ module JSONTranslate
         translation
       end
 
-      def write_json_translation(attr_name, value, locale = I18n.locale)
-        value = value.presence
+      def write_json_translation(attr_name, value, locale = I18n.locale, allow_blank: false)
+        value = allow_blank ? value : value.presence
         translation_store = "#{attr_name}#{SUFFIX}"
         translations = public_send(translation_store) || {}
         public_send("#{translation_store}_will_change!") unless translations[locale.to_s] == value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class Post < ActiveRecord::Base
 end
 
 class PostDetailed < Post
-  translates :comment
+  translates :comment, allow_blank: true
 end
 
 class JSONTranslate::Test < Minitest::Test

--- a/test/translates_test.rb
+++ b/test/translates_test.rb
@@ -24,6 +24,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_current_locale_with_fallbacks
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => {"en" => "English Title"}, :body_1_translations => { "en" => "English Body" })
     I18n.with_locale(:fr) do
@@ -39,6 +40,31 @@ class TranslatesTest < JSONTranslate::Test
       p.body_1_fr = "Corps anglais"
       assert_equal("Titre français", p.title_translations["fr"])
       assert_equal("Corps anglais", p.body_1_translations["fr"])
+    end
+  end
+
+  def test_assigns_nil_value_as_standard
+    I18n.with_locale(:en) do
+      p = Post.new(:title_translations => { "en" => "English Title" })
+      p.title_fr = ""
+      p.title = ""
+      assert_nil(p.title_translations["fr"])
+      assert_nil(p.title_translations["en"])
+    end
+  end
+
+  def test_assigns_blank_value_when_active
+    # when allow_blank: true option is active
+    I18n.with_locale(:en) do
+      p = PostDetailed.new(:comment_translations => { "en" => "English Comment" }, :title_translations => { "en" => "English Comment" })
+      p.comment_fr = ""
+      p.comment = ""
+      p.title_en = nil
+      p.title = nil
+      assert_equal("", p.comment_translations["fr"])
+      assert_equal("", p.comment_translations["en"])
+      assert_nil(p.title_translations["en"])
+      assert_nil(p.title_translations["en"])
     end
   end
 
@@ -66,6 +92,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_specified_locale_with_fallbacks
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     I18n.with_locale(:fr) do
@@ -81,6 +108,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_fallback_from_empty_string
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title", "fr" => "" }, :body_1_translations => { "en" => "English Body", "fr" => "" })
     I18n.with_locale(:fr) do
@@ -96,6 +124,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_specified_locale_with_fallback_disabled
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback
@@ -108,6 +137,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_specified_locale_with_fallback_disabled_using_a_block
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.enable_fallback
@@ -135,6 +165,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_specified_locale_with_fallback_reenabled
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback
@@ -152,6 +183,7 @@ class TranslatesTest < JSONTranslate::Test
   def test_retrieves_in_specified_locale_with_fallback_reenabled_using_a_block
     I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
     I18n.default_locale = :"en-US"
+    I18n.fallbacks = I18n::Locale::Fallbacks.new(fr: :"en-US")
 
     p = Post.new(:title_translations => { "en" => "English Title" }, :body_1_translations => { "en" => "English Body" })
     p.disable_fallback


### PR DESCRIPTION
# Purpose
Hello guys,

Because "Nothing is Something", I was wondering if it is possible to take into account empty String values in your gem ?

Thanks a lot

### Actual behavior
empty String values are not stored, instead the locale is deleted.
```ruby
class Post < ActiveRecord::Base
  translates :title
end

post.title_translations # => { en: 'Hello', fr: 'Bonjour' }
post.title_en = "" 
post.title_translations # => { fr: 'Bonjour' }
post.title_en = nil
post.title_translations # => { fr: 'Bonjour' }
```

### Future behavior
empty String values are stored.
```ruby
class Post < ActiveRecord::Base
  translates :title, allow_blank: true
end

post.title_translations # => { en: 'Hello', fr: 'Bonjour' }
post.title_en = "" 
post.title_translations # => { en: '', fr: 'Bonjour' }
post.title_en = nil
post.title_translations # => { fr: 'Bonjour' }
```