### PR TITLE
Fix deprecation warning in Ruby 2.7

### DIFF
--- a/lib/json_translate/translates.rb
+++ b/lib/json_translate/translates.rb
@@ -19,7 +19,7 @@ module JSONTranslate
 
       attrs.each do |attr_name|
         define_method attr_name do |**params|
-          read_json_translation(attr_name, params)
+          read_json_translation(attr_name, **params)
         end
 
         define_method "#{attr_name}=" do |value|
@@ -30,7 +30,7 @@ module JSONTranslate
           normalized_locale = locale.to_s.downcase.gsub(/[^a-z]/, '')
 
           define_method :"#{attr_name}_#{normalized_locale}" do |**params|
-            read_json_translation(attr_name, locale, false, params)
+            read_json_translation(attr_name, locale, false, **params)
           end
 
           define_method "#{attr_name}_#{normalized_locale}=" do |value|


### PR DESCRIPTION
This PR fixes deprecation warning in Ruby 2.7:
".rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/json_translate-4.0.0/lib/json_translate/translates.rb:33: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call"